### PR TITLE
Add event dispatching support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ composer.lock
 composer-psalm.lock
 composer.phar
 /vendor
+.idea

--- a/composer-psalm.json
+++ b/composer-psalm.json
@@ -25,7 +25,8 @@
         }
     },
     "require": {
-        "omnipay/common": "~2.0"
+        "omnipay/common": "~2.0",
+        "vimeo/payment-gateway-logger": "^1.0"
     },
     "require-dev": {
         "omnipay/tests": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     },
     "require": {
         "omnipay/common": "~2.0",
-        "vimeo/payment-gateway-logger": "^1.0"
+        "vimeo/payment-gateway-logger": "^1.0",
+        "ext-simplexml": "*"
     },
     "require-dev": {
         "omnipay/tests": "~2.0"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         }
     },
     "require": {
-        "omnipay/common": "~2.0"
+        "omnipay/common": "~2.0",
+        "vimeo/payment-gateway-logger": "^1.0"
     },
     "require-dev": {
         "omnipay/tests": "~2.0"

--- a/psalm_plugins/StringChecker.php
+++ b/psalm_plugins/StringChecker.php
@@ -16,7 +16,7 @@ class StringChecker extends \Psalm\Plugin
      * Checks an expression
      *
      * @param  StatementsChecker    $statements_checker
-     * @param  \PhpParser\Node\Expr  $stmt
+     * @param  PhpParser\Node\Expr   $stmt
      * @param  Context               $context
      * @param  CodeLocation          $code_location
      * @param  array<string>         $suppressed_issues
@@ -24,7 +24,7 @@ class StringChecker extends \Psalm\Plugin
      */
     public function checkExpression(
         StatementsChecker $statements_checker,
-        \PhpParser\Node\Expr $stmt,
+        PhpParser\Node\Expr $stmt,
         Context $context,
         CodeLocation $code_location,
         array $suppressed_issues
@@ -37,7 +37,7 @@ class StringChecker extends \Psalm\Plugin
 
                 $project_checker = $statements_checker->getFileChecker()->project_checker;
                 if (Checker\ClassChecker::checkFullyQualifiedClassLikeName(
-                    $project_checker,
+                    $statements_checker,
                     $fq_class_name,
                     $code_location,
                     $suppressed_issues

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -317,8 +317,10 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             }
         }
 
+        $eventDispatcher = $this->httpClient->getEventDispatcher();
+
         // don't throw exceptions for errors
-        $this->httpClient->getEventDispatcher()->addListener(
+        $eventDispatcher->addListener(
             // @codingStandardsIgnoreStart
             'request.error',
             /**
@@ -340,16 +342,13 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             $data
         );
 
-        /**
-         * @var \Guzzle\Http\Message\RequestInterface
-         */
         $httpRequest = $httpRequest
-                      ->setHeader(
-                          'Authorization',
-                          'Basic ' . base64_encode(($this->getUsername() ?: '') . ':' . ($this->getPassword() ?: ''))
-                      )
-                      ->setHeader('Content-Type', 'application/xml')
-                      ->setHeader('bluesnap-version', self::API_VERSION);
+            ->setHeader(
+                'Authorization',
+                'Basic ' . base64_encode(($this->getUsername() ?: '') . ':' . ($this->getPassword() ?: ''))
+            )
+            ->setHeader('Content-Type', 'application/xml')
+            ->setHeader('bluesnap-version', self::API_VERSION);
         $httpResponse = $httpRequest->send();
 
         // responses can be XML, JSON, or plain text depending on the request and whether it's successful

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -4,6 +4,7 @@ namespace Omnipay\BlueSnap\Message;
 
 use DateTime;
 use Exception;
+use Guzzle\Http\Message\RequestInterface;
 use Omnipay\BlueSnap\Constants;
 use Omnipay\Common\Exception\InvalidRequestException;
 use Omnipay\Common\Exception\RuntimeException;
@@ -342,6 +343,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             }
         );
 
+        /** @var RequestInterface $httpRequest */
         $httpRequest = $this->httpClient->createRequest(
             $this->getHttpMethod(),
             $this->getEndpoint(),
@@ -349,13 +351,14 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             $data
         );
 
-        $httpRequest = $httpRequest
+        $httpRequest
             ->setHeader(
                 'Authorization',
                 'Basic ' . base64_encode(($this->getUsername() ?: '') . ':' . ($this->getPassword() ?: ''))
             )
             ->setHeader('Content-Type', 'application/xml')
             ->setHeader('bluesnap-version', self::API_VERSION);
+
         $httpResponse = null;
         try {
             // Fire a request event before sending request.

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -359,13 +359,14 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             ->setHeader('Content-Type', 'application/xml')
             ->setHeader('bluesnap-version', self::API_VERSION);
 
+        // Fire a request event before sending request.
+        $eventDispatcher->dispatch(
+            PaymentGatewayLoggerConstants::OMNIPAY_REQUEST_BEFORE_SEND,
+            new RequestEvent($this)
+        );
+
         $httpResponse = null;
         try {
-            // Fire a request event before sending request.
-            $eventDispatcher->dispatch(
-                PaymentGatewayLoggerConstants::OMNIPAY_REQUEST_BEFORE_SEND,
-                new RequestEvent($this)
-            );
 
             $httpResponse = $httpRequest->send();
         } catch (Exception $e) {

--- a/src/Message/HostedCheckoutDecryptReturnUrlRequest.php
+++ b/src/Message/HostedCheckoutDecryptReturnUrlRequest.php
@@ -55,7 +55,7 @@ class HostedCheckoutDecryptReturnUrlRequest extends ExtendedAbstractRequest
 {
     /**
      * @return SimpleXMLElement
-     * @psalm-suppress PossiblyInvalidArrayAccess
+     * @psalm-suppress PossiblyInvalidArrayAccess because the existence of the key is checked first before using it.
      */
     public function getData()
     {

--- a/src/Message/HostedCheckoutDecryptReturnUrlRequest.php
+++ b/src/Message/HostedCheckoutDecryptReturnUrlRequest.php
@@ -55,6 +55,7 @@ class HostedCheckoutDecryptReturnUrlRequest extends ExtendedAbstractRequest
 {
     /**
      * @return SimpleXMLElement
+     * @psalm-suppress PossiblyInvalidArrayAccess
      */
     public function getData()
     {

--- a/src/Message/IPNCallback.php
+++ b/src/Message/IPNCallback.php
@@ -76,6 +76,7 @@ class IPNCallback
      * $ipn can be a full URL, just the query string, or the value of the $_POST variable.
      *
      * @param string|array<string, string> $ipn
+     * @psalm-suppress PossiblyInvalidArrayAccess
      */
     public function __construct($ipn)
     {

--- a/src/Message/IPNCallback.php
+++ b/src/Message/IPNCallback.php
@@ -76,7 +76,7 @@ class IPNCallback
      * $ipn can be a full URL, just the query string, or the value of the $_POST variable.
      *
      * @param string|array<string, string> $ipn
-     * @psalm-suppress PossiblyInvalidArrayAccess
+     * @psalm-suppress PossiblyInvalidArrayAccess because the existence of the key is checked first before using it.
      */
     public function __construct($ipn)
     {

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -99,7 +99,7 @@ class Response extends AbstractResponse
      * Get the error message from the response. Returns null if request was successful.
      *
      * @return string|null
-     * @psalm-suppress MixedPropertyFetch
+     * @psalm-suppress MixedPropertyFetch because we check the data typing before using.
      */
     public function getMessage()
     {

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -99,6 +99,7 @@ class Response extends AbstractResponse
      * Get the error message from the response. Returns null if request was successful.
      *
      * @return string|null
+     * @psalm-suppress MixedPropertyFetch
      */
     public function getMessage()
     {
@@ -428,7 +429,7 @@ class Response extends AbstractResponse
     public function getSubscriptions()
     {
         // data can be SimpleXMLElement or JSON object
-        if (!isset($this->data['data']) && !isset($this->data)) {
+        if (!isset($this->data) && !isset($this->data['data'])) {
             return null;
         }
 

--- a/tests/EventEmitterTest.php
+++ b/tests/EventEmitterTest.php
@@ -42,7 +42,6 @@ class EventEmitterTest extends OmnipayBlueSnapTestCase
     /**
      * Ensures that 'Request' and 'Response' events are emitted when issuing a request.
      *
-     * @psalm-suppress UndefinedMethod
      * @return void
      */
     public function testAuthorizeRequestSuccessfulResponseEmitted()
@@ -96,7 +95,7 @@ class EventEmitterTest extends OmnipayBlueSnapTestCase
     /**
      * Ensures that 'Request' and 'Error' events are emitted when issuing an improper request.
      *
-     * @psalm-suppress UndefinedMethod
+     * @psalm-suppress UndefinedMethod because Psalm can't infer that it exists in the Mock object but it does!
      * @return void
      */
     public function testAuthorizeRequestErrorEventEmitted()

--- a/tests/EventEmitterTest.php
+++ b/tests/EventEmitterTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Omnipay\BlueSnap;
+
+use Omnipay\BlueSnap\Message\ExtendedCancelSubscriptionRequest;
+use Omnipay\BlueSnap\Test\Framework\DataFaker;
+use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\TestSubscriber;
+use PaymentGatewayLogger\Event\Constants;
+use PaymentGatewayLogger\Event\RequestEvent;
+use PaymentGatewayLogger\Event\ResponseEvent;
+use PaymentGatewayLogger\Test\Framework\TestLogger;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class EventEmitterTest extends TestCase
+{
+    protected $customHttpClient;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    protected $eventDispatcher;
+
+    /**
+     * @var TestSubscriber
+     */
+    protected $testSubscriber;
+
+    /**
+     * @var string
+     */
+    private $subscriptionReference;
+
+    /**
+     * Ensures that 'Request' and 'Response' events are emitted when issuing a request.
+     *
+     * @return void
+     */
+    public function testAuthorizeRequestSuccessfulResponseEmitted()
+    {
+        $faker = new DataFaker();
+        $subscriptionReference = $faker->subscriptionReference();
+
+        $this->setMockHttpResponse('ExtendedCancelSubscriptionSuccess.txt', array(
+            'SUBSCRIPTION_REFERENCE' => $subscriptionReference
+        ));
+
+        $testSubscriber = new TestSubscriber($faker->name(), new TestLogger());
+        $customHttpClient = $this->getHttpClient();
+        $eventDispatcher = $customHttpClient->getEventDispatcher();
+
+        $eventDispatcher->addSubscriber($testSubscriber);
+
+        $request = new ExtendedCancelSubscriptionRequest($customHttpClient, $this->getHttpRequest());
+        $request->setSubscriptionReference($subscriptionReference);
+
+        $class = $this;
+        $eventDispatcher
+            ->addListener(
+                Constants::OMNIPAY_REQUEST_BEFORE_SEND,
+                /** @return void */
+                function (RequestEvent $event) use ($class) {
+                    $request = $event['request'];
+                     $class->assertInstanceOf('Omnipay\BlueSnap\Message\ExtendedCancelSubscriptionRequest', $request);
+                }
+            );
+
+        $eventDispatcher
+            ->addListener(
+                Constants::OMNIPAY_RESPONSE_SUCCESS,
+                /** @return void */
+                function (ResponseEvent $event) use ($class) {
+                    $response = $event['response'];
+                    $class->assertInstanceOf('\Omnipay\BlueSnap\Message\Response', $response);
+                }
+            );
+
+        $response = $request->send();
+        $this->assertTrue($response->isSuccessful());
+
+        $eventsDispatched = $testSubscriber->eventsDispatched;
+
+        $this->assertEquals(1, $eventsDispatched[Constants::OMNIPAY_REQUEST_BEFORE_SEND]);
+        $this->assertEquals(1, $eventsDispatched[Constants::OMNIPAY_RESPONSE_SUCCESS]);
+        $this->assertArrayNotHasKey(Constants::OMNIPAY_REQUEST_ERROR, $eventsDispatched);
+    }
+}

--- a/tests/EventEmitterTest.php
+++ b/tests/EventEmitterTest.php
@@ -2,14 +2,18 @@
 
 namespace Omnipay\BlueSnap;
 
+use Exception;
+use Guzzle\Http\Message\RequestInterface;
 use Omnipay\BlueSnap\Message\ExtendedCancelSubscriptionRequest;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\Tests\TestCase;
 use Omnipay\BlueSnap\Test\Framework\TestSubscriber;
 use PaymentGatewayLogger\Event\Constants;
+use PaymentGatewayLogger\Event\ErrorEvent;
 use PaymentGatewayLogger\Event\RequestEvent;
 use PaymentGatewayLogger\Event\ResponseEvent;
 use PaymentGatewayLogger\Test\Framework\TestLogger;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class EventEmitterTest extends TestCase
@@ -32,27 +36,37 @@ class EventEmitterTest extends TestCase
     private $subscriptionReference;
 
     /**
+     * @var DataFaker
+     */
+    private $faker;
+
+    protected function setUp()
+    {
+        $this->faker = new DataFaker();
+        $this->subscriptionReference = $this->faker->subscriptionReference();
+
+        parent::setUp();
+    }
+
+    /**
      * Ensures that 'Request' and 'Response' events are emitted when issuing a request.
      *
      * @return void
      */
     public function testAuthorizeRequestSuccessfulResponseEmitted()
     {
-        $faker = new DataFaker();
-        $subscriptionReference = $faker->subscriptionReference();
-
         $this->setMockHttpResponse('ExtendedCancelSubscriptionSuccess.txt', array(
-            'SUBSCRIPTION_REFERENCE' => $subscriptionReference
+            'SUBSCRIPTION_REFERENCE' => $this->subscriptionReference
         ));
 
-        $testSubscriber = new TestSubscriber($faker->name(), new TestLogger());
+        $testSubscriber = new TestSubscriber($this->faker->name(), new TestLogger());
         $customHttpClient = $this->getHttpClient();
         $eventDispatcher = $customHttpClient->getEventDispatcher();
 
         $eventDispatcher->addSubscriber($testSubscriber);
 
         $request = new ExtendedCancelSubscriptionRequest($customHttpClient, $this->getHttpRequest());
-        $request->setSubscriptionReference($subscriptionReference);
+        $request->setSubscriptionReference($this->subscriptionReference);
 
         $class = $this;
         $eventDispatcher
@@ -83,5 +97,79 @@ class EventEmitterTest extends TestCase
         $this->assertEquals(1, $eventsDispatched[Constants::OMNIPAY_REQUEST_BEFORE_SEND]);
         $this->assertEquals(1, $eventsDispatched[Constants::OMNIPAY_RESPONSE_SUCCESS]);
         $this->assertArrayNotHasKey(Constants::OMNIPAY_REQUEST_ERROR, $eventsDispatched);
+    }
+
+    /**
+     * Ensures that 'Request' and 'Error' events are emitted when issuing an improper request.
+     *
+     * @return void
+     */
+    public function testAuthorizeRequestErrorEventEmitted()
+    {
+        $this->setMockHttpResponse('ExtendedCancelSubscriptionFailure.txt', array(
+            'SUBSCRIPTION_REFERENCE' => $this->subscriptionReference
+        ));
+
+        $testSubscriber = new TestSubscriber($this->faker->name(), new TestLogger());
+        $customHttpClient = $this->getMock(
+            'Guzzle\Http\Client',
+            array('getEventDispatcher', 'addSubscriber', 'createRequest')
+        );
+        $customHttpClient->method('getEventDispatcher')->willReturn(new EventDispatcher());
+
+        // Mock the Guzzle request so that it throws an error
+        $guzzle_request_mock = $this->getMock(
+            'Guzzle\Http\Message\EntityEnclosingRequest',
+            array('setHeader'),
+            array(RequestInterface::POST, $this->faker->url())
+        );
+        $guzzle_request_mock->method('setHeader')->willReturnSelf();
+        $customHttpClient->method('createRequest')->willReturn($guzzle_request_mock);
+
+        $eventDispatcher = $customHttpClient->getEventDispatcher();
+        $eventDispatcher->addSubscriber($testSubscriber);
+
+        $request = new ExtendedCancelSubscriptionRequest($customHttpClient, $this->getHttpRequest());
+        $request->setSubscriptionReference($this->subscriptionReference);
+
+        $class = $this;
+        $eventDispatcher
+            ->addListener(
+                Constants::OMNIPAY_REQUEST_BEFORE_SEND,
+                /** @return void */
+                function (RequestEvent $event) use ($class) {
+                    $request = $event['request'];
+                    $class->assertInstanceOf('Omnipay\BlueSnap\Message\ExtendedCancelSubscriptionRequest', $request);
+                }
+            );
+
+        $eventDispatcher
+            ->addListener(
+                Constants::OMNIPAY_REQUEST_ERROR,
+                /** @return void */
+                function (ErrorEvent $event) use ($class) {
+                    $error = $event['error'];
+                    $class->assertInstanceOf('Guzzle\Common\Exception\RuntimeException', $error);
+                }
+            );
+
+        $eventsDispatched  = array();
+        $response = null;
+        try {
+            $response = $request->send();
+            $this->fail();
+        } catch (Exception $exception) {
+            // We want to resume program execution to check events in $eventsDispatched.
+            $eventsDispatched = $testSubscriber->eventsDispatched;
+            $this->assertEquals('A client must be set on the request', $exception->getMessage());
+        }
+
+        $this->assertNull($response);
+
+        // An exception will always be expected. Therefore $eventsDispatched should never be empty.
+        $this->assertNotEmpty($eventsDispatched);
+        $this->assertEquals(1, $eventsDispatched[Constants::OMNIPAY_REQUEST_BEFORE_SEND]);
+        $this->assertEquals(1, $eventsDispatched[Constants::OMNIPAY_REQUEST_ERROR]);
+        $this->assertArrayNotHasKey(Constants::OMNIPAY_RESPONSE_SUCCESS, $eventsDispatched);
     }
 }

--- a/tests/EventEmitterTest.php
+++ b/tests/EventEmitterTest.php
@@ -6,7 +6,7 @@ use Exception;
 use Guzzle\Http\Client;
 use Guzzle\Http\Message\RequestInterface;
 use Omnipay\BlueSnap\Message\ExtendedCancelSubscriptionRequest;
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\TestSubscriber;
 use Omnipay\Common\Message\ResponseInterface;
 use PaymentGatewayLogger\Event\Constants;
@@ -16,7 +16,7 @@ use PaymentGatewayLogger\Event\ResponseEvent;
 use PaymentGatewayLogger\Test\Framework\TestLogger;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
-class EventEmitterTest extends TestCase
+class EventEmitterTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var string

--- a/tests/Framework/MockPlugin.php
+++ b/tests/Framework/MockPlugin.php
@@ -11,7 +11,7 @@ class MockPlugin extends \Guzzle\Plugin\Mock\MockPlugin
      * Get a mock response from a file
      *
      * This extension adds supports for substitutions in the file, as described
-     * in \Omnipay\BlueSnap\TestCase::setMockHttpResponse
+     * in \Omnipay\BlueSnap\OmnipayBlueSnapTestCase::setMockHttpResponse
      *
      * @param string $path File to retrieve a mock response from
      * @param array<string, string> $substitutions default array()

--- a/tests/Framework/MockPlugin.php
+++ b/tests/Framework/MockPlugin.php
@@ -39,9 +39,13 @@ class MockPlugin extends \Guzzle\Plugin\Mock\MockPlugin
      * Add a response to the end of the queue
      *
      * @param Response|string $response Response object or path to response file
+     *
      * @return MockPlugin
-     * @throws InvalidArgumentException if a string or Response is not passed
+     * @throws InvalidArgumentException if a string or Response is not passed or if a Response object cannot be created
+     *                                  from the provided response file path.
+     *
      * @psalm-suppress FailedTypeResolution because we want run time checks
+     * @psalm-suppress RedundantConditionGivenDocblockType because we want run time checks on $response
      */
     public function addResponse($response)
     {
@@ -50,6 +54,10 @@ class MockPlugin extends \Guzzle\Plugin\Mock\MockPlugin
                 throw new InvalidArgumentException('Invalid response');
             }
             $response = self::getMockFile($response);
+
+            if ($response === false) {
+                throw new InvalidArgumentException('Unable to create a response object from the file path');
+            }
         }
 
         $this->queue[] = $response;

--- a/tests/Framework/OmnipayBlueSnapTestCase.php
+++ b/tests/Framework/OmnipayBlueSnapTestCase.php
@@ -7,10 +7,10 @@ use Guzzle\Http\Message\RequestInterface as GuzzleRequestInterface;
 use Guzzle\Common\Event;
 use Guzzle\Http\Message\Response;
 
-class TestCase extends \Omnipay\Tests\TestCase
+class OmnipayBlueSnapTestCase extends \Omnipay\Tests\TestCase
 {
     /**
-     * This has to be added since the Omnipay TestCase declares private variables
+     * This has to be added since the Omnipay OmnipayBlueSnapTestCase declares private variables
      * instead of protected variables.
      *
      * @var array

--- a/tests/Framework/TestSubscriber.php
+++ b/tests/Framework/TestSubscriber.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * omnipay-bluesnap
+ *
+ * @version    1
+ */
+
+namespace Omnipay\BlueSnap\Test\Framework;
+
+
+use Guzzle\Common\Event;
+use PaymentGatewayLogger\Event\Constants;
+use PaymentGatewayLogger\Event\Subscriber\OmnipayGatewayRequestSubscriber;
+
+class TestSubscriber extends OmnipayGatewayRequestSubscriber
+{
+    const PRIORITY = 0;
+
+    /** @var array */
+    public $eventsDispatched = array();
+
+    /**
+     * Triggers a log write before a request is sent.
+     *
+     * The event will be converted to an array before being logged. It will contain the following properties:
+     *     array(
+     *         'request' => \Omnipay\Common\Message\AbstractRequest
+     *     )
+     * @param Event $event
+     * @return void
+     */
+    public function onOmnipayRequestBeforeSend(Event $event)
+    {
+        $this->incrementEventCount(Constants::OMNIPAY_REQUEST_BEFORE_SEND);
+    }
+
+    /**
+     * Triggers a log write when a request completes.
+     *
+     * The event will be converted to an array before being logged. It will contain the following properties:
+     *     array(
+     *         'response' => \Omnipay\Common\Message\AbstractResponse
+     *     )
+     * @param Event $event
+     * @return void
+     */
+    public function onOmnipayResponseSuccess(Event $event)
+    {
+        $this->incrementEventCount(Constants::OMNIPAY_RESPONSE_SUCCESS);
+    }
+
+    /**
+     * Triggers a log write when a request fails.
+     *
+     * The event will be converted to an array before being logged. It will contain the following properties:
+     *     array(
+     *         'error' => Exception
+     *     )
+     * @param Event $event
+     * @return void
+     */
+    public function onOmnipayRequestError(Event $event)
+    {
+        $this->incrementEventCount(Constants::OMNIPAY_REQUEST_ERROR);
+    }
+
+    /**
+     * Increments event occurrences.
+     * @param string $event_name
+     * @return void
+     */
+    protected function incrementEventCount($event_name)
+    {
+        if (isset($this->eventsDispatched[$event_name])) {
+            $this->eventsDispatched[$event_name]++;
+        } else {
+            $this->eventsDispatched[$event_name] = 1;
+        }
+    }
+}

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -3,11 +3,11 @@
 namespace Omnipay\BlueSnap\Message;
 
 use Mockery;
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 use DateTimeZone;
 
-class AbstractRequestTest extends TestCase
+class AbstractRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/ExtendedAbstractRequestTest.php
+++ b/tests/Message/ExtendedAbstractRequestTest.php
@@ -3,11 +3,11 @@
 namespace Omnipay\BlueSnap\Message;
 
 use Mockery;
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 use SimpleXMLElement;
 
-class ExtendedAbstractRequestTest extends TestCase
+class ExtendedAbstractRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/ExtendedCancelSubscriptionRequestTest.php
+++ b/tests/Message/ExtendedCancelSubscriptionRequestTest.php
@@ -2,10 +2,10 @@
 
 namespace Omnipay\BlueSnap\Message;
 
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 
-class ExtendedCancelSubscriptionRequestTest extends TestCase
+class ExtendedCancelSubscriptionRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/ExtendedFetchCustomerRequestTest.php
+++ b/tests/Message/ExtendedFetchCustomerRequestTest.php
@@ -2,10 +2,10 @@
 
 namespace Omnipay\BlueSnap\Message;
 
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 
-class ExtendedFetchCustomerRequestTest extends TestCase
+class ExtendedFetchCustomerRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/ExtendedFetchSubscriptionChargeRequestTest.php
+++ b/tests/Message/ExtendedFetchSubscriptionChargeRequestTest.php
@@ -3,10 +3,10 @@
 namespace Omnipay\BlueSnap\Message;
 
 use DateTime;
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 
-class ExtendedFetchSubscriptionChargeRequestTest extends TestCase
+class ExtendedFetchSubscriptionChargeRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/ExtendedFetchSubscriptionRequestTest.php
+++ b/tests/Message/ExtendedFetchSubscriptionRequestTest.php
@@ -3,10 +3,10 @@
 namespace Omnipay\BlueSnap\Message;
 
 use DateTime;
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 
-class ExtendedFetchSubscriptionRequestTest extends TestCase
+class ExtendedFetchSubscriptionRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/ExtendedFetchSubscriptionsRequestTest.php
+++ b/tests/Message/ExtendedFetchSubscriptionsRequestTest.php
@@ -3,10 +3,10 @@
 namespace Omnipay\BlueSnap\Message;
 
 use DateTime;
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 
-class ExtendedFetchSubscriptionsRequestTest extends TestCase
+class ExtendedFetchSubscriptionsRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/ExtendedFetchTransactionRequestTest.php
+++ b/tests/Message/ExtendedFetchTransactionRequestTest.php
@@ -2,11 +2,11 @@
 
 namespace Omnipay\BlueSnap\Message;
 
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 use DateTime;
 
-class ExtendedFetchTransactionRequestTest extends TestCase
+class ExtendedFetchTransactionRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/ExtendedReactivateSubscriptionRequestTest.php
+++ b/tests/Message/ExtendedReactivateSubscriptionRequestTest.php
@@ -2,10 +2,10 @@
 
 namespace Omnipay\BlueSnap\Message;
 
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 
-class ExtendedReactivateSubscriptionRequestTest extends TestCase
+class ExtendedReactivateSubscriptionRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/ExtendedRefundRequestTest.php
+++ b/tests/Message/ExtendedRefundRequestTest.php
@@ -2,13 +2,13 @@
 
 namespace Omnipay\BlueSnap\Message;
 
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 use DateTime;
 use DateTimeZone;
 use Mockery;
 
-class ExtendedRefundRequestTest extends TestCase
+class ExtendedRefundRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/ExtendedTestChargeSubscriptionRequestTest.php
+++ b/tests/Message/ExtendedTestChargeSubscriptionRequestTest.php
@@ -2,10 +2,10 @@
 
 namespace Omnipay\BlueSnap\Message;
 
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 
-class ExtendedTestChargeSubscriptionRequestTest extends TestCase
+class ExtendedTestChargeSubscriptionRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/ExtendedUpdateSubscriptionRequestTest.php
+++ b/tests/Message/ExtendedUpdateSubscriptionRequestTest.php
@@ -3,10 +3,10 @@
 namespace Omnipay\BlueSnap\Message;
 
 use DateTime;
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 
-class ExtendedUpdateSubscriptionRequestTest extends TestCase
+class ExtendedUpdateSubscriptionRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/FetchCanceledSubscriptionsRequestTest.php
+++ b/tests/Message/FetchCanceledSubscriptionsRequestTest.php
@@ -2,12 +2,12 @@
 
 namespace Omnipay\BlueSnap\Message;
 
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 use DateTime;
 use DateTimeZone;
 
-class FetchCanceledSubscriptionsRequestTest extends TestCase
+class FetchCanceledSubscriptionsRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/FetchSubscriptionsRequestTest.php
+++ b/tests/Message/FetchSubscriptionsRequestTest.php
@@ -2,13 +2,13 @@
 
 namespace Omnipay\BlueSnap\Message;
 
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 use DateTime;
 use DateTimeZone;
 use Mockery;
 
-class FetchSubscriptionsRequestTest extends TestCase
+class FetchSubscriptionsRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/FetchTransactionsRequestTest.php
+++ b/tests/Message/FetchTransactionsRequestTest.php
@@ -2,13 +2,13 @@
 
 namespace Omnipay\BlueSnap\Message;
 
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 use DateTime;
 use DateTimeZone;
 use Mockery;
 
-class FetchTransactionsRequestTest extends TestCase
+class FetchTransactionsRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/HostedCheckoutDecryptReturnUrlRequestTest.php
+++ b/tests/Message/HostedCheckoutDecryptReturnUrlRequestTest.php
@@ -2,10 +2,10 @@
 
 namespace Omnipay\BlueSnap\Message;
 
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 
-class HostedCheckoutDecryptReturnUrlRequestTest extends TestCase
+class HostedCheckoutDecryptReturnUrlRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/HostedCheckoutPurchaseRequestTest.php
+++ b/tests/Message/HostedCheckoutPurchaseRequestTest.php
@@ -4,10 +4,10 @@ namespace Omnipay\BlueSnap\Message;
 
 use Omnipay\BlueSnap\UrlParameterBag;
 use Omnipay\BlueSnap\UrlParameter;
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 
-class HostedCheckoutPurchaseRequestTest extends TestCase
+class HostedCheckoutPurchaseRequestTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker

--- a/tests/Message/IPNCallbackTest.php
+++ b/tests/Message/IPNCallbackTest.php
@@ -2,11 +2,11 @@
 
 namespace Omnipay\BlueSnap\Message;
 
-use Omnipay\BlueSnap\Test\Framework\TestCase;
+use Omnipay\BlueSnap\Test\Framework\OmnipayBlueSnapTestCase;
 use Omnipay\BlueSnap\Test\Framework\DataFaker;
 use ReflectionClass;
 
-class IPNCallbackTest extends TestCase
+class IPNCallbackTest extends OmnipayBlueSnapTestCase
 {
     /**
      * @var DataFaker


### PR DESCRIPTION
* Dispatches omnipay-specific events in `Abstract` request.
* Adds unit for ensuring events are fired.