### PR TITLE
Set refundId

### DIFF
--- a/src/Message/ExtendedResponse.php
+++ b/src/Message/ExtendedResponse.php
@@ -503,6 +503,7 @@ class ExtendedResponse extends AbstractResponse
                         'amount' => (string) $financial_transaction->amount,
                         'currency' => (string) $financial_transaction->currency,
                         'refundReference' => (string) $invoice->{'invoice-id'},
+                        'refundId' => (string) $invoice->{'invoice-id'},
                         'time' => (string) $financial_transaction->{'date-created'},
                         'transactionReference' => (string) $invoice->{'original-invoice-id'},
                     );

--- a/src/Message/Refund.php
+++ b/src/Message/Refund.php
@@ -81,7 +81,7 @@ class Refund
      * This value will match refundReference. In other gateways the refund id would contain the client-specified
      * refund id but BlueSnap does not support this.
      *
-     * @return null|string
+     * @return string
      */
     public function getRefundId()
     {
@@ -102,7 +102,7 @@ class Refund
     /**
      * Get the refund reference
      *
-     * @return null|string
+     * @return string
      */
     public function getRefundReference()
     {

--- a/src/Message/Refund.php
+++ b/src/Message/Refund.php
@@ -76,7 +76,10 @@ class Refund
     }
 
     /**
-     * Get the refund id
+     * Get the refund id.
+     *
+     * This value will match refundReference. In other gateways the refund id would contain the client-specified
+     * refund id but BlueSnap does not support this.
      *
      * @return null|string
      */

--- a/src/Message/ReportingResponse.php
+++ b/src/Message/ReportingResponse.php
@@ -128,6 +128,7 @@ class ReportingResponse extends AbstractResponse
                 'time' => new DateTime($row['Transaction Date'], new DateTimeZone(Constants::BLUESNAP_TIME_ZONE)),
                 'reason' => $row['Refund / Chargeback Reason'],
                 'refundReference' => $row['Invoice ID'],
+                'refundId' => $row['Invoice ID'],
                 'transactionReference' => $row['Original Invoice ID'],
             );
 

--- a/tests/Message/ExtendedFetchTransactionRequestTest.php
+++ b/tests/Message/ExtendedFetchTransactionRequestTest.php
@@ -286,6 +286,7 @@ class ExtendedFetchTransactionRequestTest extends OmnipayBlueSnapTestCase
         $this->assertSame($amount, $refund->getAmount());
         $this->assertSame($currency, $refund->getCurrency());
         $this->assertSame($reversal_reference, $refund->getRefundReference());
+        $this->assertSame($reversal_reference, $refund->getRefundId());
         $this->assertSame($reversal_date, $refund->getTime());
         $this->assertSame($this->transactionReference, $refund->getTransactionReference());
     }

--- a/tests/Message/ReportingFetchTransactionsRequestTest.php
+++ b/tests/Message/ReportingFetchTransactionsRequestTest.php
@@ -266,6 +266,7 @@ class ReportingFetchTransactionsRequestTest extends OmnipayBlueSnapTestCase
         $this->assertInstanceOf('\Omnipay\BlueSnap\Message\Refund', $refund);
         $this->assertSame($sale_transaction_reference, $refund->getTransactionReference());
         $this->assertSame($refund_transaction_reference, $refund->getRefundReference());
+        $this->assertSame($refund_transaction_reference, $refund->getRefundId());
 
         /** @var DateTime $actual_date */
         $actual_date =  $refund->getTime();


### PR DESCRIPTION
Sets the `refundId` property when constructing refund from gateway reponse. In other gateways this value would contain the merchant-specified refund id but BlueSnap does not support this. This PR makes sure that `getRefundId` will return a non-nullable value.