### PR TITLE
[TXNS-1496] Add message support for auth only single charge

### DIFF
--- a/src/Message/IPNCallback.php
+++ b/src/Message/IPNCallback.php
@@ -107,7 +107,7 @@ class IPNCallback
 
     /**
      * Is this a AUTH_ONLY_SINGLE_CHARGE IPN? This IPN is fired when
-     * a result of zero dollar transaction is made.
+     * a zero dollar transaction is made.
      *
      * @return bool
      */

--- a/src/Message/IPNCallback.php
+++ b/src/Message/IPNCallback.php
@@ -106,6 +106,17 @@ class IPNCallback
     }
 
     /**
+     * Is this a AUTH_ONLY_SINGLE_CHARGE IPN? This IPN is fired when
+     * a result of zero dollar transaction is made.
+     *
+     * @return bool
+     */
+    public function isAuthOnlySingleCharge()
+    {
+        return $this->getIPNType() === 'AUTH_ONLY_SINGLE_CHARGE';
+    }
+
+    /**
      * Is this a CANCELLATION IPN? Cancellation IPNs are fired when a recurring charge
      * is cancelled.
      *

--- a/tests/Message/IPNCallbackTest.php
+++ b/tests/Message/IPNCallbackTest.php
@@ -75,6 +75,19 @@ class IPNCallbackTest extends OmnipayBlueSnapTestCase
     /**
      * @return void
      */
+    public function testIsAuthOnlySingleCharge()
+    {
+        $callback = new IPNCallback($this->queryString . '&transactionType=AUTH_ONLY_SINGLE_CHARGE');
+        $this->assertTrue($callback->isAuthOnlySingleCharge());
+        $callback = new IPNCallback($this->faker->url() . '?transactionType=AUTH_ONLY_SINGLE_CHARGE&' . $this->queryString);
+        $this->assertTrue($callback->isAuthOnlySingleCharge());
+        $callback = new IPNCallback($this->queryString . '&transactionType=CANCELLATION');
+        $this->assertFalse($callback->isAuthOnlySingleCharge());
+    }
+
+    /**
+     * @return void
+     */
     public function testIsCancellation()
     {
         $callback = new IPNCallback($this->queryString . '&transactionType=CANCELLATION');


### PR DESCRIPTION
[TXNS-1496](https://vimean.atlassian.net/browse/TXNS-1496)

Description: 

Bluesnap will fire off a new ipn when a 0 amount is charge which will be use to support free trials.  In order to take advantage of this, we will have to add support for AUTH_ONLY_SINGLE_CHARGE to IPNCallBack. 